### PR TITLE
change docName value in ali.xml files to correspond to html files

### DIFF
--- a/dat/BarbeBleue_BlueBeard.ali.xml
+++ b/dat/BarbeBleue_BlueBeard.ali.xml
@@ -1,7 +1,7 @@
 <trAnnot xmlns="http://transread.limsi.fr" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" xsi:schemaLocation="http://transread.limsi.fr/Resources/transread.xsd">
   <docList>
-    <docName id="doc_fr" xml:lang="fr">FR-normalized.html</docName>
-    <docName id="doc_en" xml:lang="en">EN-normalized.html</docName>
+    <docName id="doc_fr" xml:lang="fr">La-Barbe-Bleue-normalized.html</docName>
+    <docName id="doc_en" xml:lang="en">BlueBeard-normalized.html</docName>
   </docList>
   <linkList level="chunk">
     <linkGroup id="1" type="alignment">

--- a/dat/ChatBotte_MasterCat.ali.xml
+++ b/dat/ChatBotte_MasterCat.ali.xml
@@ -1,7 +1,7 @@
 <trAnnot xmlns="http://transread.limsi.fr" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" xsi:schemaLocation="http://transread.limsi.fr/Resources/transread.xsd">
   <docList>
-    <docName id="doc_fr" xml:lang="fr">FR-normalized.html</docName>
-    <docName id="doc_en" xml:lang="en">EN-normalized.html</docName>
+    <docName id="doc_fr" xml:lang="fr">ChatBotte_normalized.html</docName>
+    <docName id="doc_en" xml:lang="en">MasterCat_normalized.html</docName>
   </docList>
   <linkList level="chunk">
     <linkGroup id="1" type="alignment">

--- a/dat/LaVision_TheVision.ali.xml
+++ b/dat/LaVision_TheVision.ali.xml
@@ -1,7 +1,7 @@
 <trAnnot xmlns="http://transread.limsi.fr" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" xsi:schemaLocation="http://transread.limsi.fr/Resources/transread.xsd">
   <docList>
-    <docName id="doc_fr" xml:lang="fr">FR-normalized.html</docName>
-    <docName id="doc_en" xml:lang="en">EN-normalized.html</docName>
+    <docName id="doc_fr" xml:lang="fr">lavision_normalized.html</docName>
+    <docName id="doc_en" xml:lang="en">thevision_normalized.html</docName>
   </docList>
   <linkList level="chunk">
     <linkGroup id="1" type="alignment">

--- a/dat/Laderniereclasse_Thelastlesson.ali.xml
+++ b/dat/Laderniereclasse_Thelastlesson.ali.xml
@@ -1,7 +1,7 @@
 <trAnnot xmlns="http://transread.limsi.fr" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1" xsi:schemaLocation="http://transread.limsi.fr/Resources/transread.xsd">
   <docList>
-    <docName id="doc_fr" xml:lang="fr">FR-normalized.html</docName>
-    <docName id="doc_en" xml:lang="en">EN-normalized.html</docName>
+    <docName id="doc_fr" xml:lang="fr">laderniereclasse_normalized.html</docName>
+    <docName id="doc_en" xml:lang="en">thelastlesson_normalized.html</docName>
   </docList>
   <linkList level="chunk">
     <linkGroup id="1" type="alignment">


### PR DESCRIPTION
Change from FR-normalized.html, EN-normalized.html as docNames in all the .ali.xml files to the corresponding .html files (e.g. La-Barbe-Bleue-normalized.html, BlueBeard-normalized.html)